### PR TITLE
fix undo index going out of bounds in some cases

### DIFF
--- a/src/LRTEditor.UndoPlugin.js
+++ b/src/LRTEditor.UndoPlugin.js
@@ -36,15 +36,15 @@ var LRTEditor_UndoPlugin = {};
 			return;
 		}
 
-		if (undoIndex)
+		if (undoIndex !== null)
 		{
 			// suppose we have 4 revisions in our buffer and ctr+z'ed to undoIndex=2
 			// if anything is now typed we truncate buffers 3 & 4
 			while (undoIndex < revisions.length-1)
 				revisions.pop()
-
-			undoIndex = null;
 		}
+
+		undoIndex = null;
 
 		editor.stripHtml();
 
@@ -58,21 +58,24 @@ var LRTEditor_UndoPlugin = {};
 	{
 		if (e.ctrlKey && 90 == e.keyCode) // ctrl+z
 		{
-			if (undoIndex == null)
-				undoIndex = revisions.length-1;
+			if (undoIndex === null)
+				undoIndex = revisions.length - 1;
 
 			undoIndex--;
 
 			if (undoIndex < 0)
+			{
+				undoIndex = 0;
 				return;
+			}
 		}
-		else if (e.ctrlKey && 89 == e.keyCode && undoIndex != null) // ctrl+y
+		else if (e.ctrlKey && 89 == e.keyCode && undoIndex !== null) // ctrl+y
 		{
 			undoIndex++;
 
 			if (undoIndex > revisions.length-1)
 			{
-				undoIndex--;
+				undoIndex = revisions.length-1;
 				return;
 			}
 		}


### PR DESCRIPTION
Undoindex went a little wonky in some cases

For instance, hitting control Z over and over would make it negative and then while trying to prune the revisions it would get in an infinite loop.  There also were some oddities when undoing all the way to the first entry and it wouldn't prune them.
