### PR TITLE
use textContent instead of stripping HTML in undo

### DIFF
--- a/src/LRTEditor.UndoPlugin.js
+++ b/src/LRTEditor.UndoPlugin.js
@@ -46,8 +46,6 @@ var LRTEditor_UndoPlugin = {};
 			undoIndex = null;
 		}
 
-		editor.stripHtml();
-
 		revisions.push({text: editor.element.textContent, selection: editor.selection});
 
 		if (revisions.length > maxRevisions)


### PR DESCRIPTION
Use textContent directly when pushing undo revisions
