### PR TITLE
CommonJS compatibility

### DIFF
--- a/src/LRTEditor.FormPlugin.js
+++ b/src/LRTEditor.FormPlugin.js
@@ -1,5 +1,10 @@
 var LRTEditor_FormPlugin = {};
 
+// Expose as CommonJS module.
+if(typeof module != "undefined" && typeof module.exports == "object") {
+	module.exports = LRTEditor_FormPlugin;
+}
+
 (function()
 {
 	"use strict"

--- a/src/LRTEditor.HighlightPlugin.js
+++ b/src/LRTEditor.HighlightPlugin.js
@@ -1,5 +1,10 @@
 var LRTEditor_HighlightPlugin = {};
 
+// Expose as CommonJS module.
+if(typeof module != "undefined" && typeof module.exports == "object") {
+	module.exports = LRTEditor_HighlightPlugin;
+}
+
 (function()
 {
 	"use strict"

--- a/src/LRTEditor.MinimalPlugin.js
+++ b/src/LRTEditor.MinimalPlugin.js
@@ -1,5 +1,10 @@
 var LRTEditor_MinimalPlugin = {};
 
+// Expose as CommonJS module.
+if(typeof module != "undefined" && typeof module.exports == "object") {
+	module.exports = LRTEditor_MinimalPlugin;
+}
+
 (function()
 {
 	"use strict"

--- a/src/LRTEditor.UndoPlugin.js
+++ b/src/LRTEditor.UndoPlugin.js
@@ -1,5 +1,10 @@
 var LRTEditor_UndoPlugin = {};
 
+// Expose as CommonJS module.
+if(typeof module != "undefined" && typeof module.exports == "object") {
+	module.exports = LRTEditor_UndoPlugin;
+}
+
 (function()
 {
 	"use strict"

--- a/src/LRTEditor.js
+++ b/src/LRTEditor.js
@@ -1,5 +1,10 @@
 var LRTEditor = {};
 
+// Expose as CommonJS module.
+if(typeof module != "undefined" && typeof module.exports == "object") {
+	module.exports = LRTEditor;
+}
+
 (function()
 {
 	"use strict"


### PR DESCRIPTION
## Effect:

This PR makes LRTEditor usable by module bundlers such as:
- WebPack
- Browserify
- Rollup
## Background:

I am working with WebPack and I am building an editor widget. I want to use LRTEditor as a starting point, and in fact make it a dependency of the project. The other part consists in obtaining a Markdown parser/highlighter, which I already have - now I just need to bring the two together. To do so, I needed CommonJS compatibility.
## What's left?

You can publish this on NPM and/or Bower now. The only thing to keep in mind:
- When `npm init` asks about the "entry file" or "main file", set it to `src/LRTEditor.js`.

Enjoy!
### Links:

WebPack: http://webpack.github.io/
Browserify: http://browserify.org/
Rollup: http://rollupjs.org/
NPM: http://npmjs.org
